### PR TITLE
- Unify naming for a unique lxqt. No more prefixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CPP_FILES
 find_package(Qt5Widgets REQUIRED QUIET)
 find_package(Qt5DBus REQUIRED QUIET)
 find_package(Qt5X11Extras REQUIRED QUIET)
-find_package(lxqt-qt5 REQUIRED QUIET)
+find_package(lxqt REQUIRED QUIET)
 include(${LXQT_USE_FILE})
 
 include_directories(


### PR DESCRIPTION
Signed-off-by: Helio Chissini de Castro helio@kde.org
