### PR TITLE
Removes local compile definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ set(LXQT_ABOUT_PATCH_VERSION 0)
 set(LXQT_ABOUT_VERSION ${LXQT_MAJOR_VERSION}.${LXQT_MINOR_VERSION}.${LXQT_ABOUT_PATCH_VERSION})
 add_definitions(
     "-DLXQT_ABOUT_VERSION=\"${LXQT_ABOUT_VERSION}\""
-    "-DQT_NO_FOREACH"
 )
 
 # Translations **********************************


### PR DESCRIPTION
QT_NO_FOREACH is already part of LXQtCompilerSettings CMake module.