### PR TITLE
aboutdialog: remove extraneous leading space

### DIFF
--- a/aboutdialog/lxqtaboutdialog.ui
+++ b/aboutdialog/lxqtaboutdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string> About LXQt</string>
+   <string>About LXQt</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>


### PR DESCRIPTION
A minor issue noted in comments on weblate. But still would be nice to have it fixed.